### PR TITLE
Bug fix: Working default options file

### DIFF
--- a/lib/saito/core/storage-core.ts
+++ b/lib/saito/core/storage-core.ts
@@ -271,9 +271,42 @@ class StorageCore extends Storage {
       }
     } else {
       // default options file
-      this.app.options = JSON.parse(
-        '{"server":{"host":"localhost","port":12101,"protocol":"http"}}'
-      );
+      const defaultOptions = `
+        {
+          "server": {
+            "host": "127.0.0.1",
+            "port": 12101,
+            "protocol": "http",
+            "endpoint": {
+              "host": "127.0.0.1",
+              "port": 12101,
+              "protocol": "http"
+            },
+            "verification_threads": 4,
+            "channel_size": 10000,
+            "stat_timer_in_ms": 5000,
+            "reconnection_wait_time": 10000,
+            "thread_sleep_time_in_ms": 10,
+            "block_fetch_batch_size": 10
+          },
+          "peers": [],
+          "spv_mode": false,
+          "browser_mode": false,
+          "blockchain":{
+            "last_block_hash":"0000000000000000000000000000000000000000000000000000000000000000",
+            "last_block_id":0,
+            "last_timestamp":0,
+            "genesis_block_id":0,
+            "genesis_timestamp":0,
+            "lowest_acceptable_timestamp":0,
+            "lowest_acceptable_block_hash":"0000000000000000000000000000000000000000000000000000000000000000",
+            "lowest_acceptable_block_id":0
+          },
+          "wallet": {
+          }
+        }
+      `;
+      this.app.options = JSON.parse(defaultOptions);
     }
     return this.app.options;
   }


### PR DESCRIPTION
Problem: If you're starting from scratch with saito-lite-rust and following the directions, you'll go down the "default options file" path, but with the minimal version there, the server fails to start -- first from JSON validation errors in the WasmConfiguration and later (after you patch that up) from errors initializing the blockchain.

Solution: This default config is from `options.conf.template`, so another fix would be to try and load from that file if it's ok to assume it exists.